### PR TITLE
update examples with schedule mechanism

### DIFF
--- a/draft-ma-opsawg-ucl-acl.md
+++ b/draft-ma-opsawg-ucl-acl.md
@@ -414,7 +414,7 @@ file="ietf-schedule@2023-01-19.yang"
 }
 ~~~~
 
-   The period starting at 08:00:00 UTC, on January 1, 2023 and lasting 15 days and
+   An example of a period that starts at 08:00:00 UTC, on January 1, 2023 and lasts 15 days and
    5 hours and 20 minutes:
 
 ~~~~

--- a/draft-ma-opsawg-ucl-acl.md
+++ b/draft-ma-opsawg-ucl-acl.md
@@ -441,14 +441,14 @@ file="ietf-schedule@2023-01-19.yang"
 
   The following snippet can be used to indicate a daily recurrent in December:
 
-~~~
+~~~~
 {
   "recurrence": {
     "freq": "daily",
-    "bymonth": "12"
+    "byyearmonth": [12]
   }
 }
-~~~
+~~~~
 
    The following snippet can be used to indicate 10 occurrences that occur every last Saturday of the month:
 
@@ -456,11 +456,13 @@ file="ietf-schedule@2023-01-19.yang"
 {
   "recurrence": {
     "freq": "monthly",
-    "count": "10",
-    "byday": {
-      "direction": "-1",
-      "weekday": "saturday"
-    }
+    "count": 10,
+    "byday": [
+      {
+        "direction": [-1],
+        "weekday": "saturday"
+      }
+    ]
   }
 }
 ~~~~
@@ -479,10 +481,11 @@ file="ietf-schedule@2023-01-19.yang"
       { "weekday": "thursday" },
       { "weekday": "friday" }
     ],
-    "bysetpos": "-1"
+    "bysetpos": [-1]
   }
 }
 ~~~~
+
 
    Every other week on Tuesday and Sunday, the week starts from Monday:
 
@@ -490,7 +493,7 @@ file="ietf-schedule@2023-01-19.yang"
 {
   "recurrence": {
     "freq": "weekly",
-    "interval": "2",
+    "interval": 2,
     "byday": [
       { "weekday": "tuesday" },
       { "weekday": "sunday" }

--- a/draft-ma-opsawg-ucl-acl.md
+++ b/draft-ma-opsawg-ucl-acl.md
@@ -402,7 +402,7 @@ file="ietf-schedule@2023-01-19.yang"
 
 #### Period of Time
 
-   The period starting at 08:00:00 UTC, on January 1, 2023 and ending at 18:00:00 UTC
+   The example of a period that starts at 08:00:00 UTC, on January 1, 2023 and ends at 18:00:00 UTC
    on December 31, 2025:
 
 ~~~~

--- a/draft-ma-opsawg-ucl-acl.md
+++ b/draft-ma-opsawg-ucl-acl.md
@@ -394,6 +394,113 @@ file="ietf-schedule@2023-01-19.yang"
 <CODE ENDS>
 ~~~~
 
+
+### Examples
+
+   Here are some delicated examples of period and recurrence formats defined as
+   YANG groupings. The data is provided in JSON.
+
+#### Period of Time
+
+   The period starting at 08:00:00 UTC, on January 1, 2023 and ending at 18:00:00 UTC
+   on December 31, 2025:
+
+~~~~
+{
+  "period-of-time": {
+    "explicit-start": "2023-01-01T08:00:00Z",
+    "explicit-end": "2025-12-01T18:00:00Z"
+  }
+}
+~~~~
+
+   The period starting at 08:00:00 UTC, on January 1, 2023 and lasting 15 days and
+   5 hours and 20 minutes:
+
+~~~~
+{
+  "period-of-time": {
+    "start": "2023-01-01T08:00:00Z",
+    "duration": "P15DT05:20:00"
+  }
+}
+~~~~
+
+   The period starting at 08:00:00 UTC, on January 1, 2023 and lasting 20 weeks:
+
+~~~~
+{
+  "period-of-time": {
+    "start": "2023-01-01T08:00:00Z",
+    "duration": "P20W"
+  }
+}
+~~~~
+
+#### Recurrence Rule
+
+  Every day in December
+
+~~~
+{
+  "recurrence": {
+    "freq": "daily",
+    "bymonth": "12"
+  }
+}
+~~~  
+
+   10 occurrences that occur every last Saturday of the month:
+
+~~~~
+{
+  "recurrence": {
+    "freq": "monthly",
+    "count": "10",
+    "byday": {
+      "direction": "-1",
+      "weekday": "saturday"
+    }
+  }
+}
+~~~~     
+
+   The last workday of the month, until December 25, 2023:
+
+~~~~
+{
+  "recurrence": {
+    "freq": "monthly",
+    "until": "2023-12-25",    
+    "byday": [
+      { "weekday": "monday" },
+      { "weekday": "tuesday" },
+      { "weekday": "wednesday" },
+      { "weekday": "thursday" },
+      { "weekday": "friday" }
+    ],
+    "bysetpos": "-1"
+  }
+}
+~~~~
+
+   Every other week on Tuesday and Sunday, the week starts from Monday:
+
+~~~
+{
+  "recurrence": {
+    "freq": "weekly",
+    "interval": "2",
+    "byday": [
+      { "weekday": "tuesday" },
+      { "weekday": "sunday" }
+    ],
+    "wkst": "monday"
+  }
+}
+~~~   
+
+
 ##  The UCL Extension to the ACL Model {#sec-UCL}
 
 ###  Module Overview
@@ -601,10 +708,13 @@ CoA-Request CoA-ACK CoA-NACK #        Attribute
 
    The access requirements are as follows:
 
-   * Permit traffic from R&D BYOD of employees, destined to R&D employees' devices.
+   * Permit traffic from R&D BYOD of employees, destined to R&D employees'
+     devices every work day from 8:00 to 18:00.
 
    * Deny traffic from R&D BYOD of employees, destined to finance servers
-     located in the enterprise DC network.
+     located in the enterprise DC network starting at 8:30:00 of January 20,
+     2023 with an offset of -08:00 from UTC (Pacific Standard Time) and ending
+     at 18:00:00 in Pacific Standard Time on December 31, 2023.
 
    The following example illustrates the configuration of the SDN controller
    using the group-based ACL:

--- a/draft-ma-opsawg-ucl-acl.md
+++ b/draft-ma-opsawg-ucl-acl.md
@@ -471,7 +471,7 @@ file="ietf-schedule@2023-01-19.yang"
 {
   "recurrence": {
     "freq": "monthly",
-    "until": "2023-12-25",    
+    "until": "2023-12-25", 
     "byday": [
       { "weekday": "monday" },
       { "weekday": "tuesday" },

--- a/draft-ma-opsawg-ucl-acl.md
+++ b/draft-ma-opsawg-ucl-acl.md
@@ -465,7 +465,7 @@ file="ietf-schedule@2023-01-19.yang"
 }
 ~~~~
 
-   The last workday of the month, until December 25, 2023:
+   The following indicates the example of a recurrence that occurs last workday of the month until December 25, 2023:
 
 ~~~~
 {

--- a/draft-ma-opsawg-ucl-acl.md
+++ b/draft-ma-opsawg-ucl-acl.md
@@ -403,7 +403,7 @@ file="ietf-schedule@2023-01-19.yang"
 #### Period of Time
 
    The example of a period that starts at 08:00:00 UTC, on January 1, 2023 and ends at 18:00:00 UTC
-   on December 31, 2025:
+   on December 31, 2025 is encoded as follows:
 
 ~~~~
 {

--- a/draft-ma-opsawg-ucl-acl.md
+++ b/draft-ma-opsawg-ucl-acl.md
@@ -439,7 +439,7 @@ file="ietf-schedule@2023-01-19.yang"
 
 #### Recurrence Rule
 
-  Every day in December
+  The following snippet can be used to indicate a daily recurrent in December:
 
 ~~~
 {

--- a/draft-ma-opsawg-ucl-acl.md
+++ b/draft-ma-opsawg-ucl-acl.md
@@ -448,7 +448,7 @@ file="ietf-schedule@2023-01-19.yang"
     "bymonth": "12"
   }
 }
-~~~  
+~~~
 
    10 occurrences that occur every last Saturday of the month:
 
@@ -463,7 +463,7 @@ file="ietf-schedule@2023-01-19.yang"
     }
   }
 }
-~~~~     
+~~~~
 
    The last workday of the month, until December 25, 2023:
 
@@ -471,7 +471,7 @@ file="ietf-schedule@2023-01-19.yang"
 {
   "recurrence": {
     "freq": "monthly",
-    "until": "2023-12-25", 
+    "until": "2023-12-25",
     "byday": [
       { "weekday": "monday" },
       { "weekday": "tuesday" },
@@ -498,7 +498,7 @@ file="ietf-schedule@2023-01-19.yang"
     "wkst": "monday"
   }
 }
-~~~   
+~~~
 
 
 ##  The UCL Extension to the ACL Model {#sec-UCL}

--- a/draft-ma-opsawg-ucl-acl.md
+++ b/draft-ma-opsawg-ucl-acl.md
@@ -415,7 +415,7 @@ file="ietf-schedule@2023-01-19.yang"
 ~~~~
 
    An example of a period that starts at 08:00:00 UTC, on January 1, 2023 and lasts 15 days and
-   5 hours and 20 minutes:
+   5 hours and 20 minutes is encoded as follows:
 
 ~~~~
 {

--- a/draft-ma-opsawg-ucl-acl.md
+++ b/draft-ma-opsawg-ucl-acl.md
@@ -450,7 +450,7 @@ file="ietf-schedule@2023-01-19.yang"
 }
 ~~~
 
-   10 occurrences that occur every last Saturday of the month:
+   The following snippet can be used to indicate 10 occurrences that occur every last Saturday of the month:
 
 ~~~~
 {

--- a/draft-ma-opsawg-ucl-acl.md
+++ b/draft-ma-opsawg-ucl-acl.md
@@ -426,7 +426,7 @@ file="ietf-schedule@2023-01-19.yang"
 }
 ~~~~
 
-   The period starting at 08:00:00 UTC, on January 1, 2023 and lasting 20 weeks:
+   Now, consider the example of a period that starts at 08:00:00 UTC, on January 1, 2023 and lasts 20 weeks:
 
 ~~~~
 {

--- a/draft-ma-opsawg-ucl-acl.md
+++ b/draft-ma-opsawg-ucl-acl.md
@@ -397,7 +397,7 @@ file="ietf-schedule@2023-01-19.yang"
 
 ### Examples
 
-   Here are some delicated examples of period and recurrence formats defined as
+   Here are some examples to illustrate the use of the period and recurrence formats defined as
    YANG groupings. The data is provided in JSON.
 
 #### Period of Time

--- a/draft-ma-opsawg-ucl-acl.md
+++ b/draft-ma-opsawg-ucl-acl.md
@@ -398,7 +398,7 @@ file="ietf-schedule@2023-01-19.yang"
 ### Examples
 
    Here are some examples to illustrate the use of the period and recurrence formats defined as
-   YANG groupings. The data is provided in JSON.
+   YANG groupings. Only the message body is provided with JSON used for encoding {{?RFC7951}}
 
 #### Period of Time
 

--- a/draft-ma-opsawg-ucl-acl.md
+++ b/draft-ma-opsawg-ucl-acl.md
@@ -467,7 +467,7 @@ file="ietf-schedule@2023-01-19.yang"
 }
 ~~~~
 
-   The following indicates the example of a recurrence that occurs last workday of the month until December 25, 2023:
+   The following indicates the example of a recurrence that occurs on the last workday of the month until December 25, 2023:
 
 ~~~~
 {

--- a/examples/PEP-acl.xml
+++ b/examples/PEP-acl.xml
@@ -17,6 +17,28 @@
         <actions>
           <forwarding>accept</forwarding>
         </actions>
+        <time-range xmlns="urn:ietf:params:xml:ns:yang:ietf-ucl-acl">
+          <recurrence>
+            <freq>daily</freq>
+            <byhour>8</byhour>
+            <byday>
+              <weekday>monday</weekday>
+            </byday>
+            <byday>
+              <weekday>tuesday</weekday>
+            </byday> 
+            <byday>            
+              <weekday>wednesday</weekday>
+            </byday> 
+            <byday>            
+              <weekday>thursday</weekday>
+            </byday>
+            <byday>            
+              <weekday>friday</weekday>              
+            </byday>  
+            <duration>PT10:00:00</duration>
+          </recurrence>
+        </time-range>         
       </ace>
       <ace>
         <name>rule2</name>
@@ -30,6 +52,12 @@
         <actions>
           <forwarding>reject</forwarding>
         </actions>
+        <time-range xmlns="urn:ietf:params:xml:ns:yang:ietf-ucl-acl">
+          <period-of-time>
+            <explicit-start>2023-01-20T08:30:00-08:00</explicit-start>
+            <explicit-end>2023-12-31T18:00:00-08:00</explicit-end>
+          </period-of-time>
+        </time-range>        
       </ace>
     </aces>
   </acl>

--- a/examples/PEP-ucl.xml
+++ b/examples/PEP-ucl.xml
@@ -33,6 +33,28 @@
         <actions>
           <forwarding>accept</forwarding>
         </actions>
+        <time-range xmlns="urn:ietf:params:xml:ns:yang:ietf-ucl-acl">
+          <recurrence>
+            <freq>daily</freq>
+            <byhour>8</byhour>
+            <byday>
+              <weekday>monday</weekday>
+            </byday>
+            <byday>
+              <weekday>tuesday</weekday>
+            </byday> 
+            <byday>            
+              <weekday>wednesday</weekday>
+            </byday> 
+            <byday>            
+              <weekday>thursday</weekday>
+            </byday>
+            <byday>            
+              <weekday>friday</weekday>              
+            </byday>  
+            <duration>PT10:00:00</duration>
+          </recurrence>
+        </time-range>          
       </ace>
       <ace>
         <name>rule2</name>
@@ -49,6 +71,12 @@
         <actions>
           <forwarding>reject</forwarding>
         </actions>
+        <time-range xmlns="urn:ietf:params:xml:ns:yang:ietf-ucl-acl">
+          <period-of-time>
+            <explicit-start>2023-01-20T08:30:00-08:00</explicit-start>
+            <explicit-end>2023-12-31T18:00:00-08:00</explicit-end>
+          </period-of-time>
+        </time-range>        
       </ace>
     </aces>
   </acl>

--- a/examples/controller-ucl.xml
+++ b/examples/controller-ucl.xml
@@ -39,6 +39,28 @@
         <actions>
           <forwarding>accept</forwarding>
         </actions>
+        <time-range xmlns="urn:ietf:params:xml:ns:yang:ietf-ucl-acl">
+          <recurrence>
+            <freq>daily</freq>
+            <byhour>8</byhour>
+            <byday>
+              <weekday>monday</weekday>
+            </byday>
+            <byday>
+              <weekday>tuesday</weekday>
+            </byday> 
+            <byday>            
+              <weekday>wednesday</weekday>
+            </byday> 
+            <byday>            
+              <weekday>thursday</weekday>
+            </byday>
+            <byday>            
+              <weekday>friday</weekday>              
+            </byday>  
+            <duration>PT10:00:00</duration>
+          </recurrence>
+        </time-range>  
       </ace>
       <ace>
         <name>rule2</name>
@@ -52,6 +74,12 @@
         <actions>
           <forwarding>reject</forwarding>
         </actions>
+        <time-range xmlns="urn:ietf:params:xml:ns:yang:ietf-ucl-acl">
+          <period-of-time>
+            <explicit-start>2023-01-20T08:30:00-08:00</explicit-start>
+            <explicit-end>2023-12-31T18:00:00-08:00</explicit-end>
+          </period-of-time>
+        </time-range>
       </ace>
     </aces>
   </acl>

--- a/yang/ietf-schedule-tree.txt
+++ b/yang/ietf-schedule-tree.txt
@@ -29,4 +29,4 @@ module: ietf-schedule
        +-- byyearweek*    int32
        +-- byyearmonth*   uint32
        +-- bysetpos*      int32
-       +-- wkst*          schedule:weekday
+       +-- wkst?          schedule:weekday

--- a/yang/ietf-schedule.yang
+++ b/yang/ietf-schedule.yang
@@ -343,7 +343,7 @@ module ietf-schedule {
            specified by the rule. It must only be used in conjunction
            with another byXXX rule part.";
       }
-      leaf-list wkst {
+      leaf wkst {
         type schedule:weekday;
         default "monday";
         description


### PR DESCRIPTION
Adding delicated examples to show how to use period and recurrence formats defined in ietf schedule YANG module; update examples in Appendix considering schedule and period mechanism. All of the examples have passed the yanglint validation.