### PR TITLE
update schedule yang

### DIFF
--- a/yang/ietf-schedule-tree.txt
+++ b/yang/ietf-schedule-tree.txt
@@ -1,31 +1,95 @@
 module: ietf-schedule
 
-  grouping period:
-    +-- period-of-time
-       +-- period-start?            yang:date-and-time
-       +-- (period-type)?
-          +--:(period-explicit)
-          |  +-- period-end?        yang:date-and-time
-          +--:(period-duration)
-             +-- period-duration?   duration
+  grouping period-of-time:
+    +-- period-start?            yang:date-and-time
+    +-- time-zone-identifier?    string
+    +-- (period-type)?
+       +--:(period-explicit)
+       |  +-- period-end?        yang:date-and-time
+       +--:(period-duration)
+          +-- period-duration?   duration
   grouping recurrence:
-    +-- recurrence
-       +-- freq           enumeration
-       +-- (recurrence-bound)?
-       |  +--:(until)
-       |  |  +-- until?   union
-       |  +--:(count)
-       |     +-- count?   uint32
-       +-- interval?      uint32
-       +-- bysecond*      uint32
-       +-- byminute*      uint32
-       +-- byhour*        uint32
-       +-- byday* [weekday]
-       |  +-- direction*   int32
-       |  +-- weekday?     schedule:weekday
-       +-- bymonthday*    int32
-       +-- byyearday*     int32
-       +-- byyearweek*    int32
-       +-- byyearmonth*   uint32
-       +-- bysetpos*      int32
-       +-- wkst?          schedule:weekday
+    +-- recur-first
+    |  +-- dt-start?               union
+    |  +-- time-zone-identifier?   string
+    |  +-- duration?               duration
+    +-- freq           enumeration
+    +-- interval?      uint32
+    +-- (recurrence-bound)?
+       +--:(until)
+       |  +-- until?   union
+       +--:(count)
+          +-- count?   uint32
+  grouping recurrence-with-date-times:
+    +-- recur-first
+    |  +-- dt-start?               union
+    |  +-- time-zone-identifier?   string
+    |  +-- duration?               duration
+    +-- freq                      enumeration
+    +-- interval?                 uint32
+    +-- (recurrence-bound)?
+    |  +--:(until)
+    |  |  +-- until?              union
+    |  +--:(count)
+    |     +-- count?              uint32
+    +-- (date-times-choice)?
+       +--:(date-time)
+       |  +-- date-times*         yang:date-and-time
+       +--:(date)
+       |  +-- dates*              yang:date-no-zone
+       +--:(period-timeticks)
+       |  +-- period-timeticks* [period-start]
+       |     +-- period-start?   yang:timeticks
+       |     +-- period-end?     yang:timeticks
+       +--:(period)
+          +-- period* [period-start]
+             +-- period-start?            yang:date-and-time
+             +-- time-zone-identifier?    string
+             +-- (period-type)?
+                +--:(period-explicit)
+                |  +-- period-end?        yang:date-and-time
+                +--:(period-duration)
+                   +-- period-duration?   duration
+  grouping icalendar-recurrence:
+    +-- recur-first
+    |  +-- dt-start?               union
+    |  +-- time-zone-identifier?   string
+    |  +-- duration?               duration
+    +-- freq                      enumeration
+    +-- interval?                 uint32
+    +-- (recurrence-bound)?
+    |  +--:(until)
+    |  |  +-- until?              union
+    |  +--:(count)
+    |     +-- count?              uint32
+    +-- (date-times-choice)?
+    |  +--:(date-time)
+    |  |  +-- date-times*         yang:date-and-time
+    |  +--:(date)
+    |  |  +-- dates*              yang:date-no-zone
+    |  +--:(period-timeticks)
+    |  |  +-- period-timeticks* [period-start]
+    |  |     +-- period-start?   yang:timeticks
+    |  |     +-- period-end?     yang:timeticks
+    |  +--:(period)
+    |     +-- period* [period-start]
+    |        +-- period-start?            yang:date-and-time
+    |        +-- time-zone-identifier?    string
+    |        +-- (period-type)?
+    |           +--:(period-explicit)
+    |           |  +-- period-end?        yang:date-and-time
+    |           +--:(period-duration)
+    |              +-- period-duration?   duration
+    +-- bysecond*                 uint32
+    +-- byminute*                 uint32
+    +-- byhour*                   uint32
+    +-- byday* [weekday]
+    |  +-- direction*   int32
+    |  +-- weekday?     schedule:weekday
+    +-- bymonthday*               int32
+    +-- byyearday*                int32
+    +-- byyearweek*               int32
+    +-- byyearmonth*              uint32
+    +-- bysetpos*                 int32
+    +-- wkst?                     schedule:weekday
+    +-- exdates*                  union

--- a/yang/ietf-schedule.yang
+++ b/yang/ietf-schedule.yang
@@ -34,13 +34,19 @@ module ietf-schedule {
 
      This version of this YANG module is part of RFC XXXX
      (https://www.rfc-editor.org/info/rfcXXXX); see the RFC
-     itself for full legal notices.";
+     itself for full legal notices.
+     
+     The key words 'MUST', 'MUST NOT', 'REQUIRED', 'SHALL', 'SHALL
+     NOT', 'SHOULD', 'SHOULD NOT', 'RECOMMENDED', 'NOT RECOMMENDED',
+     'MAY', and 'OPTIONAL' in this document are to be interpreted as
+     described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
+     they appear in all capitals, as shown here.";
 
   revision 2023-01-19 {
     description
       "Initial revision.";
     reference
-      "RFC XXXX: A Policy-based Network Access Control";
+      "RFC XXXX: A YANG Data Model for Scheduling.";
   }
 
   typedef weekday {
@@ -105,252 +111,389 @@ module ietf-schedule {
       "RFC 5545: Internet Calendaring and Scheduling Core Object 
                  Specification (iCalendar), Sections 3.3.6 and 
                  3.8.6.3";    
-  }
+  } 
   
-  grouping period {
+  grouping period-of-time {
     description
       "This grouping is defined for period of time property.";
     reference 
       "RFC 5545: Internet Calendaring and Scheduling Core Object 
                  Specification (iCalendar), Section 3.3.9";      
-    container period-of-time {
+    leaf period-start {
+      type yang:date-and-time;
       description
-        "This container is defined to identify period values that
-         contain a precise period of time.";
-      leaf period-start {
-        type yang:date-and-time;
+        "Period start time.";
+    }
+    leaf time-zone-identifier {
+      type string;
+      description
+        "Indicates the identifier for the time zone in a time zone 
+         database. This parameter MUST be specified if 'period-start'
+         value is neither reported in the format of UTC nor time zone 
+         offset to UTC.";
+    }
+    choice period-type {
+      description
+        "Indicates the type of the time period. Two types are
+          supported.";
+      case period-explicit {
         description
-          "Period start time.";
-      }
-      choice period-type {
-        description
-          "Indicates the type of the time period. Two types are
-            supported.";
-        case period-explicit {
+          "A period of time is identified by its start and its end. 
+           'period-start' indicates the period start.";
+        leaf period-end {
+          type yang:date-and-time;
           description
-            "A period of time is identified by its start and its
-             end. 'period-start' indicates the period start.";
-          leaf period-end {
-            type yang:date-and-time;
-            description
-              "Period end time.";
-          }
+            "Period end time. If a local time without time zone offset
+             to UTC time is specified, it MUST use the same time zone
+             reference as 'period-start' parameter. If 'period-start' 
+             also uses a local time without time zone offset to UTC, 
+             it MUST use the time zone as specified by the 'time-zone-
+             identifier' parameter.";
         }
-        case period-duration {
-          description
-            "A period of time is defined by a start and a
-             positive duration of time.";
-          leaf period-duration {
-            type duration {
-              pattern 'P((([0-9]+)D)?(T(0[0-9]|1[0-9]|2[0-3])'
-                    + ':[0-5][0-9]:[0-5][0-9]))|P([0-9]+)W';
-            }
-            description
-              "A positive duration of the time. This value is 
-               equivalent to the format of duration type except that 
-               the value cannot be negative.";
+      }
+      case period-duration {
+        description
+          "A period of time is defined by a start and a
+           positive duration of time.";
+        leaf period-duration {
+          type duration {
+            pattern 'P((([0-9]+)D)?(T(0[0-9]|1[0-9]|2[0-3])'
+                  + ':[0-5][0-9]:[0-5][0-9]))|P([0-9]+)W';
           }
+          description
+            "A positive duration of the time. This value is 
+             equivalent to the format of duration type except that 
+             the value cannot be negative.";
         }
       }
     }
   }
-
+  
   grouping recurrence {
+    description
+      "A simplified definition of recurrence.";
+    container recur-first {
+      description
+        "Specifies the first instance of the recurrence.";
+      leaf dt-start {
+        type union {
+          type yang:date-no-zone;
+          type yang:date-and-time;
+        }
+        description
+          "Defines the first instance in the recurrence set. If it is
+           specified as a date-no-zone value type, the recurrence's 
+           duration is taken to be one day. It SHOULD match the 
+           pattern of the recurrence rule, if specified.";        
+      }
+      leaf time-zone-identifier {
+        type string;
+        description
+          "Indicates the identifier for the time zone in a time zone 
+           database. This parameter MUST be specified if 'start' value
+           is neither reported in the format of UTC nor time zone 
+           offset to UTC.";
+      }
+      leaf duration {
+        type duration;
+        description
+          "When optionally specified, it refers to the duration of 
+           the first occurrence. The exact duration also applies to
+           all the recurrence instance.";
+      }
+    }
+    leaf freq {
+      type enumeration {
+        enum secondly {
+          value 1;
+          description
+            "Repeating events based on an interval of a second
+             or more.";
+        }
+        enum minutely {
+          value 2;
+          description
+            "Repeating events based on an interval of a minute
+             or more.";
+        }
+        enum hourly {
+          value 3;
+          description
+            "Repeating events based on an interval of an hour
+             or more.";
+        }
+        enum daily {
+          value 4;
+          description
+            "Repeating events based on an interval of a day or
+             more.";
+        }
+        enum weekly {
+          value 5;
+          description
+            "Repeating events based on an interval of a week or
+             more.";
+        }
+        enum monthly {
+          value 6;
+          description
+            "Repeating events based on an interval of a month or
+             more.";
+        }
+        enum yearly {
+          value 7;
+          description
+            "Repeating events based on an interval of a year or
+             more.";
+        }
+      }
+      mandatory true;
+      description
+        "This parameter is defined to identify the type of
+         recurrence rule.";
+    }
+    leaf interval {
+      type uint32;
+      default "1";
+      description
+        "A positive integer representing at which intervals the
+         recurrence rule repeats. The default value is '1', 
+         meaning every second for a secondly rule, every minute
+         for a minutely rule, every hour for an hourly rule, every
+         day for a daily rule, every week for a weekly rule, every
+         month for a monthly rule, and every year for a yearly 
+         rule.";
+    }
+    choice recurrence-bound {
+      description
+        "Modes to bound the recurrence rule. If no choice is
+         indicated, the recurrence rule is considered to repeat
+         forever.";
+      case until {
+        description
+          "This case defines a way that bounds the recurrence
+           rule in an inclusive manner.";
+        leaf until {
+          type union {
+            type yang:date-no-zone;
+            type yang:date-and-time;
+          }
+          description
+            "This parameter specifies a date-no-zone or
+             date-time value to bounds the recurrence. If the value 
+             specified by this parameter is synchronized with the 
+             specified recurrence, it becomes the last instance of 
+             the recurrence. The value MUST have the same value type
+             as the value type of 'start' parameter.";
+        }
+      }
+      case count {
+        description
+          "This case defines the number of occurrences at which
+           to range-bound the recurrence.";
+        leaf count {
+          type uint32;
+          description
+            "The positive number of occurrences at which to
+             range-bound the recurrence.";
+        }
+      }
+    }
+  }
+  
+  grouping recurrence-with-date-times {
+    description
+      "This grouping defines an aggregate set of repeating occurrences.
+       The recurrence instances are defined by the union of occurrences
+       defined by both the 'recurrence' and 'date-times'. Duplicate
+       instances are ignored.";
+    uses recurrence;
+    choice date-times-choice {
+      description
+        "Specify a list of occurrences which complement the recurrence
+         set defined by 'recurrence' grouping. If it is specified as
+         a period value, the duration of the recurrence instance will 
+         be the one specified by it, and not the duration defined 
+         inside the recur-first parameter.";
+      case date-time {
+        description
+          "Specify a list of occurrences with date-and-time values.";
+          leaf-list date-times {
+            type yang:date-and-time;
+            description
+              "Specify a set of date-and-time values of occurrences.";
+          }
+      }
+      case date {
+        description
+          "Specify a list of occurrences with date-no-zone values.";
+          leaf-list dates {
+            type yang:date-no-zone;
+            description
+              "Specify a set of date-no-zone values of occurrences.";
+          }
+      }
+      case period-timeticks {
+        description
+          "Specify a list of occurrences with period span of timeticks
+           format.";
+          list period-timeticks {
+            key "period-start";
+            description
+              "A list of period with timeticks formats.";
+            leaf period-start {
+              type yang:timeticks;
+              must "((../../../freq = 'secondly') and "
+                +      "(current() < 100)) or "
+                +  "((../../../recurrence = 'minutely') and "
+                +      "(current() < 6000)) or "
+                +  "((../../../recurrence = 'hourly') and "
+                +      "(current() < 360000)) or "                 
+                +  "((../../../recurrence = 'daily') and "
+                +      "(current() < 8640000)) or "
+                +  "((../../../recurrence = 'weekly') and "
+                +      "(current() < 60480000)) or "                 
+                +  "((../../../recurrence = 'monthly') and "
+                +      "(current() < 267840000)) or "
+                +   "((../../../recurrence = 'yearly') and "
+                +      "(current() < 3162240000))"  {
+                error-message
+                  "The period-start must not exceed the frequency
+                   interval.";
+              }
+              description
+                "Start time of the scheduled value within one 
+                 recurrence.";
+            }
+            leaf period-end {
+              type yang:timeticks;
+              description
+                "End time of the scheduled value within one recurrence.";
+            }
+          }
+      }
+      case period {
+        description
+          "Specify a list of occurrences with period span of date-and
+           -time format.";
+        list period {
+          key "period-start";
+          description
+            "A list of period with date-and-time formats.";
+          uses period-of-time;          
+        }
+      }
+    }
+  }
+  
+  grouping icalendar-recurrence {
     description
       "This grouping is defined to identify properties that contain a 
        recurrence rule.";
     reference 
       "RFC 5545: Internet Calendaring and Scheduling Core Object 
-       Specification (iCalendar), Section 3.3.10";        
-    container recurrence {
+       Specification (iCalendar), Section 3.8.5";        
+
+    uses recurrence-with-date-times;
+    leaf-list bysecond {
+      type uint32 {
+        range "0..60";
+      }
       description
-        "Recurrence rule definition.";
-      leaf freq {
-        type enumeration {
-          enum secondly {
-            value 1;
-            description
-              "Repeating events based on an interval of a second
-               or more.";
-          }
-          enum minutely {
-            value 2;
-            description
-              "Repeating events based on an interval of a minute
-               or more.";
-          }
-          enum hourly {
-            value 3;
-            description
-              "Repeating events based on an interval of an hour
-               or more.";
-          }
-          enum daily {
-            value 4;
-            description
-              "Repeating events based on an interval of a day or
-               more.";
-          }
-          enum weekly {
-            value 5;
-            description
-              "Repeating events based on an interval of a week or
-               more.";
-          }
-          enum monthly {
-            value 6;
-            description
-              "Repeating events based on an interval of a month or
-               more.";
-          }
-          enum yearly {
-            value 7;
-            description
-              "Repeating events based on an interval of a year or
-               more.";
-          }
-        }
-        mandatory true;
-        description
-          "This parameter is defined to identify the type of
-           recurrence rule.";
+        "A list of seconds within a minute.";
+    }
+    leaf-list byminute {
+      type uint32 {
+        range "0..59";
       }
-      choice recurrence-bound {
-        description
-          "Modes to bound the recurrence rule. If no choice is
-           indicated, the recurrence rule is considered to repeat
-           forever.";
-        case until {
-          description
-            "This case defines a way that bounds the recurrence
-             rule in an inclusive manner.";
-          leaf until {
-            type union {
-              type yang:date-no-zone;
-              type yang:date-and-time;
-            }
-            description
-              "This parameter specifies a date-no-zone or
-               date-time value to bounds the recurrence. The 
-               specified value becomes the last instance of the
-               recurrence.";
-          }
-        }
-        case count {
-          description
-            "This case defines the number of occurrences at which
-             to range-bound the recurrence.";
-          leaf count {
-            type uint32;
-            description
-              "The positive number of occurrences at which to
-               range-bound the recurrence.";
-          }
-        }
+      description
+        "A list of minutes within an hour.";
+    }
+    leaf-list byhour {
+      type uint32 {
+        range "0..23";
       }
-      leaf interval {
-        type uint32;
-        default "1";
-        description
-          "A positive integer representing at which intervals the
-           recurrence rule repeats. The default value is '1', 
-           meaning every second for a secondly rule, every minute
-           for a minutely rule, every hour for an hourly rule, every
-           day for a daily rule, every week for a weekly rule, every
-           month for a monthly rule, and every year for a yearly 
-           rule.";
-      }
-      leaf-list bysecond {
-        type uint32 {
-          range "0..60";
-        }
-        description
-          "A list of seconds within a minute.";
-      }
-      leaf-list byminute {
-        type uint32 {
-          range "0..59";
-        }
-        description
-          "A list of minutes within an hour.";
-      }
-      leaf-list byhour {
-        type uint32 {
-          range "0..23";
-        }
-        description
-          "Specify a list of hours of the day.";
-      }
-      list byday {
-        key "weekday";
-        description
-          "Specify a list of days of the week.";
-        leaf-list direction {
-          when '(enum-value(../../freq) = 6) or ' +
-            '(enum-value(../../freq) = 7) and not(../../byyearweek)';
-          type int32 {
-            range "-53..-1|1..53";
-          }
-          description
-            "When specified, it indicates the nth occurrence of a
-             specific day within the MONTHLY or YEARLY 'RRULE'. For
-             example, within a MONTHLY rule, +1 monday represents the
-             first monday within the month, whereas -1 monday
-             represents the last monday of the month.";
-        }
-        leaf weekday {
-          type schedule:weekday;
-          description
-            "Corresponding to seven days of the week.";
-        }
-      }
-      
-      leaf-list bymonthday {
-        type int32 {
-          range "-31..-1|1..31";
-        }
-        description
-          "Specifies a list of days of the month.";
-      }
-      leaf-list byyearday {
-        type int32 {
-          range "-366..-1|1..366";
-        }
-        description
-          "Specifies a list of days of the year.";
-      }
-      leaf-list byyearweek {
-        when 'enum-value(../freq)=7';
+      description
+        "Specify a list of hours of the day.";
+    }
+    list byday {
+      key "weekday";
+      description
+        "Specify a list of days of the week.";
+      leaf-list direction {
+        when "(../../freq = 'monthly') or (../../freq = 'yearly') "
+          +  " and not(../../byyearweek)";
         type int32 {
           range "-53..-1|1..53";
         }
         description
-          "Specifies a list of weeks of the year.";
+          "When specified, it indicates the nth occurrence of a
+           specific day within the MONTHLY or YEARLY 'RRULE'. For
+           example, within a MONTHLY rule, +1 monday represents the
+           first monday within the month, whereas -1 monday
+           represents the last monday of the month.";
       }
-      leaf-list byyearmonth {
-        type uint32 {
-          range "1..12";
-        }
-        description
-          "Specifies a list of months of the year.";
-      }
-      leaf-list bysetpos {
-        type int32 {
-          range "-366..-1|1..366";
-        }
-        description
-          "Specifies a list of values that corresponds to the nth
-           occurrence within the set of recurrence instances
-           specified by the rule. It must only be used in conjunction
-           with another by the rule part.";
-      }
-      leaf wkst {
+      leaf weekday {
         type schedule:weekday;
-        default "monday";
         description
-          "Specifies the day on which the workweek starts.";
+          "Corresponding to seven days of the week.";
       }
+    }
+      
+    leaf-list bymonthday {
+      type int32 {
+        range "-31..-1|1..31";
+      }
+      description
+        "Specifies a list of days of the month.";
+    }
+    leaf-list byyearday {
+      type int32 {
+        range "-366..-1|1..366";
+      }
+      description
+        "Specifies a list of days of the year.";
+    }
+    leaf-list byyearweek {
+      when 'enum-value(../freq)=7';
+      type int32 {
+        range "-53..-1|1..53";
+      }
+      description
+        "Specifies a list of weeks of the year.";
+    }
+    leaf-list byyearmonth {
+      type uint32 {
+        range "1..12";
+      }
+      description
+        "Specifies a list of months of the year.";
+    }
+    leaf-list bysetpos {
+      type int32 {
+        range "-366..-1|1..366";
+      }
+      description
+        "Specifies a list of values that corresponds to the nth
+         occurrence within the set of recurrence instances
+         specified by the rule. It must only be used in conjunction
+         with another by the rule part.";
+    }
+    leaf wkst {
+      type schedule:weekday;
+      default "monday";
+      description
+        "Specifies the day on which the workweek starts.";
+    }
+    leaf-list exdates {
+      type union {
+        type yang:date-no-zone;
+        type yang:date-and-time;
+      }
+      description
+        "Define a list a exceptions for recurrence.";
     }
   }
 }
+
 


### PR DESCRIPTION
major updates:
1. add a time-zone-identifier parameter;
2. add new parameters(recur-first, exdates, data-time-choice) to recurrence definition
3. Define 3 recurrence related groupings. From simple to complete with the latter reusing the previous ones: recurrence, recurrence-with-date-times and icalendar-recurrence. I think the second (recurrence-with-date-times) is related to the TVR cases.