### PR TITLE
update schedule YANG data model to meet TVR requirments

### DIFF
--- a/yang/ietf-schedule-tree.txt
+++ b/yang/ietf-schedule-tree.txt
@@ -6,7 +6,7 @@ module: ietf-schedule
     +-- max-allowed-start?      yang:date-and-time
     +-- min-allowed-start?      yang:date-and-time
     +-- max-allowed-end?        yang:date-and-time
-
+    +-- discard-action?         enumeration
   grouping period-of-time:
     +-- period-start?           yang:date-and-time
     +-- time-zone-identifier?   sys:timezone-name
@@ -16,87 +16,106 @@ module: ietf-schedule
        +--:(duration)
           +-- duration?         duration
   grouping recurrence:
-    +-- recurrence-first
-    |  +-- date-time-start?        union
-    |  +-- time-zone-identifier?   sys:timezone-name
-    |  +-- duration?               duration
-    +-- frequency?          identityref
-    +-- interval?           uint32
+    +-- first-recur-date-time?   yang:date-and-time
+    +-- frequency?               identityref
+    +-- interval?                uint32
     +-- (recurrence-bound)?
        +--:(until)
-       |  +-- until?        union
+       |  +-- until?             yang:date-and-time
        +--:(count)
-          +-- count?        uint32
-  grouping recurrence-with-date-times:
-    +-- recurrence-first
-    |  +-- date-time-start?        union
-    |  +-- time-zone-identifier?   sys:timezone-name
-    |  +-- duration?               duration
-    +-- frequency?                identityref
-    +-- interval?                 uint32
+          +-- count?             uint32
+  grouping recurrence-UTC:
+    +-- first-recur-date-time?   yang:date-and-time
+    +-- frequency?               identityref
+    +-- interval?                uint32
     +-- (recurrence-bound)?
     |  +--:(until)
-    |  |  +-- until?              union
+    |  |  +-- until?             yang:date-and-time
     |  +--:(count)
-    |     +-- count?              uint32
-    +-- (date-times-choice)?
-       +--:(date-time)
-       |  +-- date-times*         yang:date-and-time
-       +--:(date)
-       |  +-- dates*              yang:date-no-zone
-       +--:(period-timeticks)
-       |  +-- period-timeticks* [period-start]
-       |     +-- period-start?   yang:timeticks
-       |     +-- period-end?     yang:timeticks
-       +--:(period)
-          +-- period* [period-start]
-             +-- period-start?           yang:date-and-time
-             +-- time-zone-identifier?   sys:timezone-name
-             +-- (period-type)?
-                +--:(explicit)
-                |  +-- period-end?       yang:date-and-time
-                +--:(duration)
-                   +-- duration?         duration
+    |     +-- count?             uint32
+    +-- duration?                yang:seconds32
+  grouping recurrence-TZ:
+    +-- first-recur-date-time?   yang:date-and-time
+    +-- frequency?               identityref
+    +-- interval?                uint32
+    +-- (recurrence-bound)?
+    |  +--:(until)
+    |  |  +-- until?             yang:date-and-time
+    |  +--:(count)
+    |     +-- count?             uint32
+    +-- duration?                duration
+    +-- time-zone-identifier?    sys:timezone-name
+  grouping recurrence-UTC-with-date-times:
+    +-- first-recur-date-time?   yang:date-and-time
+    +-- frequency?               identityref
+    +-- interval?                uint32
+    +-- (recurrence-bound)?
+    |  +--:(until)
+    |  |  +-- until?             yang:date-and-time
+    |  +--:(count)
+    |     +-- count?             uint32
+    +-- duration?                yang:seconds32
+    +-- period-timeticks* [period-start]
+       +-- period-start?   yang:timeticks
+       +-- period-end?     yang:timeticks
+  grouping recurrence-TZ-with-date-times:
+    +-- first-recur-date-time?   yang:date-and-time
+    +-- frequency?               identityref
+    +-- interval?                uint32
+    +-- (recurrence-bound)?
+    |  +--:(until)
+    |  |  +-- until?             yang:date-and-time
+    |  +--:(count)
+    |     +-- count?             uint32
+    +-- duration?                duration
+    +-- time-zone-identifier?    sys:timezone-name
+    +-- period* [period-start]
+       +-- period-start?           yang:date-and-time
+       +-- time-zone-identifier?   sys:timezone-name
+       +-- (period-type)?
+          +--:(explicit)
+          |  +-- period-end?       yang:date-and-time
+          +--:(duration)
+             +-- duration?         duration
   grouping icalendar-recurrence:
-    +-- recurrence-first
-    |  +-- date-time-start?        union
-    |  +-- time-zone-identifier?   sys:timezone-name
-    |  +-- duration?               duration
-    +-- frequency?                identityref
-    +-- interval?                 uint32
+    +-- first-recur-date-time?   yang:date-and-time
+    +-- frequency?               identityref
+    +-- interval?                uint32
     +-- (recurrence-bound)?
     |  +--:(until)
-    |  |  +-- until?              union
+    |  |  +-- until?             yang:date-and-time
     |  +--:(count)
-    |     +-- count?              uint32
-    +-- (date-times-choice)?
-    |  +--:(date-time)
-    |  |  +-- date-times*         yang:date-and-time
-    |  +--:(date)
-    |  |  +-- dates*              yang:date-no-zone
-    |  +--:(period-timeticks)
-    |  |  +-- period-timeticks* [period-start]
-    |  |     +-- period-start?   yang:timeticks
-    |  |     +-- period-end?     yang:timeticks
-    |  +--:(period)
-    |     +-- period* [period-start]
-    |        +-- period-start?           yang:date-and-time
-    |        +-- time-zone-identifier?   sys:timezone-name
-    |        +-- (period-type)?
-    |           +--:(explicit)
-    |           |  +-- period-end?       yang:date-and-time
-    |           +--:(duration)
-    |              +-- duration?         duration
-    +-- bysecond*                 uint32
-    +-- byminute*                 uint32
-    +-- byhour*                   uint32
+    |     +-- count?             uint32
+    +-- duration?                duration
+    +-- time-zone-identifier?    sys:timezone-name
+    +-- period* [period-start]
+    |  +-- period-start?           yang:date-and-time
+    |  +-- time-zone-identifier?   sys:timezone-name
+    |  +-- (period-type)?
+    |     +--:(explicit)
+    |     |  +-- period-end?       yang:date-and-time
+    |     +--:(duration)
+    |        +-- duration?         duration
+    +-- bysecond*                uint32
+    +-- byminute*                uint32
+    +-- byhour*                  uint32
     +-- byday* [weekday]
     |  +-- direction*   int32
     |  +-- weekday?     schedule:weekday
-    +-- bymonthday*               int32
-    +-- byyearday*                int32
-    +-- byyearweek*               int32
-    +-- byyearmonth*              uint32
-    +-- bysetpos*                 int32
-    +-- workweek-start?           schedule:weekday
-    +-- exception-dates*          union
+    +-- bymonthday*              int32
+    +-- byyearday*               int32
+    +-- byyearweek*              int32
+    +-- byyearmonth*             uint32
+    +-- bysetpos*                int32
+    +-- workweek-start?          schedule:weekday
+    +-- exception-dates*         union
+  grouping schedule-status:
+    +-- schedule-id?           string
+    +-- state?                 identityref
+    +-- version?               uint16
+    +--ro schedule-type?         identityref
+    +--ro last-update?           yang:date-and-time
+    +--ro counter?               uint32
+    +--ro last-occurrence?       yang:date-and-time
+    +--ro upcoming-occurrence?   yang:date-and-time
+

--- a/yang/ietf-schedule-tree.txt
+++ b/yang/ietf-schedule-tree.txt
@@ -16,59 +16,64 @@ module: ietf-schedule
        +--:(duration)
           +-- duration?         duration
   grouping recurrence:
-    +-- first-recur-date-time?   yang:date-and-time
-    +-- frequency?               identityref
-    +-- interval?                uint32
+    +-- recurrence-first
+    |  +-- date-time-start?   yang:date-and-time
+    +-- frequency?          identityref
+    +-- interval?           uint32
     +-- (recurrence-bound)?
        +--:(until)
-       |  +-- until?             yang:date-and-time
+       |  +-- until?        yang:date-and-time
        +--:(count)
-          +-- count?             uint32
+          +-- count?        uint32
   grouping recurrence-UTC:
-    +-- first-recur-date-time?   yang:date-and-time
-    +-- frequency?               identityref
-    +-- interval?                uint32
+    +-- recurrence-first
+    |  +-- date-time-start?   yang:date-and-time
+    |  +-- duration?          yang:seconds32
+    +-- frequency?          identityref
+    +-- interval?           uint32
     +-- (recurrence-bound)?
-    |  +--:(until)
-    |  |  +-- until?             yang:date-and-time
-    |  +--:(count)
-    |     +-- count?             uint32
-    +-- duration?                yang:seconds32
+       +--:(until)
+       |  +-- until?        yang:date-and-time
+       +--:(count)
+          +-- count?        uint32
   grouping recurrence-TZ:
-    +-- first-recur-date-time?   yang:date-and-time
-    +-- frequency?               identityref
-    +-- interval?                uint32
+    +-- recurrence-first
+    |  +-- date-time-start?        yang:date-and-time
+    |  +-- duration?               duration
+    |  +-- time-zone-identifier?   sys:timezone-name
+    +-- frequency?          identityref
+    +-- interval?           uint32
     +-- (recurrence-bound)?
-    |  +--:(until)
-    |  |  +-- until?             yang:date-and-time
-    |  +--:(count)
-    |     +-- count?             uint32
-    +-- duration?                duration
-    +-- time-zone-identifier?    sys:timezone-name
+       +--:(until)
+       |  +-- until?        yang:date-and-time
+       +--:(count)
+          +-- count?        uint32
   grouping recurrence-UTC-with-date-times:
-    +-- first-recur-date-time?   yang:date-and-time
-    +-- frequency?               identityref
-    +-- interval?                uint32
+    +-- recurrence-first
+    |  +-- date-time-start?   yang:date-and-time
+    |  +-- duration?          yang:seconds32
+    +-- frequency?          identityref
+    +-- interval?           uint32
     +-- (recurrence-bound)?
     |  +--:(until)
-    |  |  +-- until?             yang:date-and-time
+    |  |  +-- until?        yang:date-and-time
     |  +--:(count)
-    |     +-- count?             uint32
-    +-- duration?                yang:seconds32
+    |     +-- count?        uint32
     +-- period-timeticks* [period-start]
        +-- period-start?   yang:timeticks
        +-- period-end?     yang:timeticks
   grouping recurrence-TZ-with-date-times:
-    +-- first-recur-date-time?   yang:date-and-time
-    +-- frequency?               identityref
-    +-- interval?                uint32
+    +-- recurrence-first
+    |  +-- date-time-start?        yang:date-and-time
+    |  +-- duration?               duration
+    |  +-- time-zone-identifier?   sys:timezone-name
+    +-- frequency?          identityref
+    +-- interval?           uint32
     +-- (recurrence-bound)?
     |  +--:(until)
-    |  |  +-- until?             yang:date-and-time
+    |  |  +-- until?        yang:date-and-time
     |  +--:(count)
-    |     +-- count?             uint32
-    +-- duration?                duration
-    +-- time-zone-identifier?    sys:timezone-name
+    |     +-- count?        uint32
     +-- period* [period-start]
        +-- period-start?           yang:date-and-time
        +-- time-zone-identifier?   sys:timezone-name
@@ -78,16 +83,17 @@ module: ietf-schedule
           +--:(duration)
              +-- duration?         duration
   grouping icalendar-recurrence:
-    +-- first-recur-date-time?   yang:date-and-time
-    +-- frequency?               identityref
-    +-- interval?                uint32
+    +-- recurrence-first
+    |  +-- date-time-start?        yang:date-and-time
+    |  +-- duration?               duration
+    |  +-- time-zone-identifier?   sys:timezone-name
+    +-- frequency?          identityref
+    +-- interval?           uint32
     +-- (recurrence-bound)?
     |  +--:(until)
-    |  |  +-- until?             yang:date-and-time
+    |  |  +-- until?        yang:date-and-time
     |  +--:(count)
-    |     +-- count?             uint32
-    +-- duration?                duration
-    +-- time-zone-identifier?    sys:timezone-name
+    |     +-- count?        uint32
     +-- period* [period-start]
     |  +-- period-start?           yang:date-and-time
     |  +-- time-zone-identifier?   sys:timezone-name
@@ -96,19 +102,19 @@ module: ietf-schedule
     |     |  +-- period-end?       yang:date-and-time
     |     +--:(duration)
     |        +-- duration?         duration
-    +-- bysecond*                uint32
-    +-- byminute*                uint32
-    +-- byhour*                  uint32
+    +-- bysecond*           uint32
+    +-- byminute*           uint32
+    +-- byhour*             uint32
     +-- byday* [weekday]
     |  +-- direction*   int32
     |  +-- weekday?     schedule:weekday
-    +-- bymonthday*              int32
-    +-- byyearday*               int32
-    +-- byyearweek*              int32
-    +-- byyearmonth*             uint32
-    +-- bysetpos*                int32
-    +-- workweek-start?          schedule:weekday
-    +-- exception-dates*         union
+    +-- bymonthday*         int32
+    +-- byyearday*          int32
+    +-- byyearweek*         int32
+    +-- byyearmonth*        uint32
+    +-- bysetpos*           int32
+    +-- workweek-start?     schedule:weekday
+    +-- exception-dates*    union
   grouping schedule-status:
     +-- schedule-id?           string
     +-- state?                 identityref
@@ -118,4 +124,3 @@ module: ietf-schedule
     +--ro counter?               uint32
     +--ro last-occurrence?       yang:date-and-time
     +--ro upcoming-occurrence?   yang:date-and-time
-

--- a/yang/ietf-schedule-tree.txt
+++ b/yang/ietf-schedule-tree.txt
@@ -25,7 +25,7 @@ module: ietf-schedule
        |  +-- until?        yang:date-and-time
        +--:(count)
           +-- count?        uint32
-  grouping recurrence-UTC:
+  grouping recurrence-utc:
     +-- recurrence-first
     |  +-- date-time-start?   yang:date-and-time
     |  +-- duration?          yang:seconds32
@@ -36,7 +36,7 @@ module: ietf-schedule
        |  +-- until?        yang:date-and-time
        +--:(count)
           +-- count?        uint32
-  grouping recurrence-TZ:
+  grouping recurrence-with-time-zone:
     +-- recurrence-first
     |  +-- date-time-start?        yang:date-and-time
     |  +-- duration?               duration
@@ -48,7 +48,7 @@ module: ietf-schedule
        |  +-- until?        yang:date-and-time
        +--:(count)
           +-- count?        uint32
-  grouping recurrence-UTC-with-date-times:
+  grouping recurrence-utc-with-date-times:
     +-- recurrence-first
     |  +-- date-time-start?   yang:date-and-time
     |  +-- duration?          yang:seconds32
@@ -62,7 +62,7 @@ module: ietf-schedule
     +-- period-timeticks* [period-start]
        +-- period-start?   yang:timeticks
        +-- period-end?     yang:timeticks
-  grouping recurrence-TZ-with-date-times:
+  grouping recurrence-time-zone-with-date-times:
     +-- recurrence-first
     |  +-- date-time-start?        yang:date-and-time
     |  +-- duration?               duration

--- a/yang/ietf-schedule.yang
+++ b/yang/ietf-schedule.yang
@@ -350,11 +350,15 @@ module ietf-schedule {
   grouping recurrence {
     description
       "A simple definition of recurrence.";
-    leaf first-recur-date-time {
-      type yang:date-and-time;
+    container recurrence-first {
       description
-        "Defines the instant date and time of the first instance 
-         in the recurrence set.";
+        "Specifies the first instance of the recurrence.";
+      leaf date-time-start {
+        type yang:date-and-time;
+        description
+          "Defines the instant date and time of the first instance 
+           in the recurrence set.";
+      }  
     }
     leaf frequency {
       type identityref {
@@ -409,7 +413,7 @@ module ietf-schedule {
       "A simple definition of recurrence with time specified in 
        UTC. This grouping is intended to be machine-friendly.";  
     uses recurrence {
-      refine "first-recur-date-time" {
+      refine "recurrence-first/date-time-start" {
         description
           "Defines the instant date and time of the first instance 
            in the recurrence set. A UTC format MUST be used.";
@@ -422,12 +426,19 @@ module ietf-schedule {
            recurrence, it becomes the last instance of the 
            recurrence. A UTC format MUST be used.";
       }
-    }
-    leaf duration {
-      type yang:seconds32;
-      description
-        "When specified, it refers to the duration of each 
-         occurrence. The duration is in units of seconds.";
+      augment "recurrence-first" {
+        description
+          "Add a parameter indicating how long the occurence 
+           lasts.";
+        leaf duration {
+          type yang:seconds32;
+          description
+            "When specified, it refers to the duration of each 
+             occurrence. The duration is in units of seconds. The 
+             exact duration also applies to all the recurrence 
+             instance.";
+        }      
+      }
     }
   }
   
@@ -436,22 +447,28 @@ module ietf-schedule {
       "A simple definition of recurrence that allows the time to
        be specified with a local time and time zone. This grouping
        is intended to be human-friendly.";
-    uses recurrence;
-    leaf duration {
-      type duration;
-      description
-        "When specified, it refers to the duration of
-         the first occurrence. The exact duration also applies to
-         all the recurrence instance.";
-    }
-    leaf time-zone-identifier {
-      type sys:timezone-name;
-      description
-        "Indicates the identifier for the time zone in a time zone
-         database. This parameter MUST be specified if 
-         'first-recur-date-time' and/or 'until' value is neither 
-         reported in the format of UTC nor time zone offset to 
-         UTC.";    
+    uses recurrence {
+      augment "recurrence-first" {
+        description
+          "Add parameters indicating how long the occurence 
+           lasts and time zone identifier of the occurence.";
+        leaf duration {
+          type duration;
+          description
+            "When specified, it refers to the duration of
+             the first occurrence. The exact duration also applies to
+             all the recurrence instance.";
+        }
+        leaf time-zone-identifier {
+          type sys:timezone-name;
+          description
+            "Indicates the identifier for the time zone in a time zone
+             database. This parameter MUST be specified if 
+             'first-recur-date-time' and/or 'until' value is neither 
+             reported in the format of UTC nor time zone offset to 
+             UTC.";    
+        }      
+      }
     }
   }
 

--- a/yang/ietf-schedule.yang
+++ b/yang/ietf-schedule.yang
@@ -17,10 +17,10 @@ module ietf-schedule {
   }
 
   organization
-    "IETF OPSAWG Working Group";
+    "IETF NETMOD Working Group";
   contact
-    "WG Web: <https://datatracker.ietf.org/wg/opsawg/>
-     WG List: <mailto:opsawg@ietf.org>
+    "WG Web: <https://datatracker.ietf.org/wg/netmod/>
+     WG List: <mailto:netmod@ietf.org>
 
      Editor:   Qiufang Ma
                <mailto:maqiufang1@huawei.com
@@ -58,7 +58,7 @@ module ietf-schedule {
      described in BCP 14 (RFC 2119) (RFC 8174) when, and only when,
      they appear in all capitals, as shown here.";
 
-  revision 2023-01-19 {
+  revision 2024-04-16 {
     description
       "Initial revision.";
     reference
@@ -230,8 +230,8 @@ module ietf-schedule {
 
        These parameters apply to all schedules.
 
-        Such parameters are used as guards to prevent, e.g., stale
-        configuration.";
+       Such parameters are used as guards to prevent, e.g., stale
+       configuration.";
     leaf time-zone-identifier {
       type sys:timezone-name;
       description
@@ -350,38 +350,11 @@ module ietf-schedule {
   grouping recurrence {
     description
       "A simple definition of recurrence.";
-    container recurrence-first {
+    leaf first-recur-date-time {
+      type yang:date-and-time;
       description
-        "Specifies the first instance of the recurrence.";
-      leaf date-time-start {
-        type union {
-          type yang:date-no-zone;
-          type yang:date-and-time;
-        }
-        description
-          "Defines the first instance in the recurrence set. If it is
-           specified as a date-no-zone value type with no duration
-           specified, the recurrence's duration is taken to be one
-           day.";
-        reference
-          "RFC 5545: Internet Calendaring and Scheduling Core Object
-                     Specification (iCalendar), Section 3.3.10";
-      }
-      leaf time-zone-identifier {
-        type sys:timezone-name;
-        description
-          "Indicates the identifier for the time zone in a time zone
-           database. This parameter MUST be specified if 'start'
-           value is neither reported in the format of UTC nor time
-           zone offset to UTC.";
-      }
-      leaf duration {
-        type duration;
-        description
-          "When specified, it refers to the duration of
-           the first occurrence. The exact duration also applies to
-           all the recurrence instance.";
-      }
+        "Defines the instant date and time of the first instance 
+         in the recurrence set.";
     }
     leaf frequency {
       type identityref {
@@ -408,17 +381,13 @@ module ietf-schedule {
           "This case defines a way that bounds the recurrence
            rule in an inclusive manner.";
         leaf until {
-          type union {
-            type yang:date-no-zone;
-            type yang:date-and-time;
-          }
+          type yang:date-and-time;
           description
-            "This parameter specifies a date-no-zone or
-             date-time value to bounds the recurrence. If the value
-             specified by this parameter is synchronized with the
-             specified recurrence, it becomes the last instance of
-             the recurrence. The value MUST have the same value type
-             as the value type of 'start' parameter.";
+            "This parameter specifies a date and time value to 
+             bound the recurrence. If the value specified by this 
+             parameter is synchronized with the specified 
+             recurrence, it becomes the last instance of the 
+             recurrence.";
         }
       }
       case count {
@@ -434,110 +403,127 @@ module ietf-schedule {
       }
     }
   }
-
-  grouping recurrence-with-date-times {
+  
+  grouping recurrence-UTC {
     description
-      "This grouping defines an aggregate set of repeating
-       occurrences. The recurrence instances are defined by
-       the union of occurrences defined by both the
-       'recurrence' and 'date-times'. Duplicate instances
-       are ignored.";
-    uses recurrence;
-    choice date-times-choice {
+      "A simple definition of recurrence with time specified in 
+       UTC. This grouping is intended to be machine-friendly.";  
+    uses recurrence {
+      refine "first-recur-date-time" {
+        description
+          "Defines the instant date and time of the first instance 
+           in the recurrence set. A UTC format MUST be used.";
+      }
+      refine "recurrence-bound/until" {
+        description
+          "This parameter specifies a date and time value to 
+           bound the recurrence. If the value specified by this 
+           parameter is synchronized with the specified 
+           recurrence, it becomes the last instance of the 
+           recurrence. A UTC format MUST be used.";
+      }
+    }
+    leaf duration {
+      type yang:seconds32;
       description
-        "Specify a list of occurrences which complement the
-         recurrence set defined by 'recurrence' grouping. If
-         it is specified as a period value, the duration of
-         the recurrence instance will be the one specified
-         by it, and not the duration defined inside the
-         recurrence-first parameter.";
-      case date-time {
+        "When specified, it refers to the duration of each 
+         occurrence. The duration is in units of seconds.";
+    }
+  }
+  
+  grouping recurrence-TZ {
+    description
+      "A simple definition of recurrence that allows the time to
+       be specified with a local time and time zone. This grouping
+       is intended to be human-friendly.";
+    uses recurrence;
+    leaf duration {
+      type duration;
+      description
+        "When specified, it refers to the duration of
+         the first occurrence. The exact duration also applies to
+         all the recurrence instance.";
+    }
+    leaf time-zone-identifier {
+      type sys:timezone-name;
+      description
+        "Indicates the identifier for the time zone in a time zone
+         database. This parameter MUST be specified if 
+         'first-recur-date-time' and/or 'until' value is neither 
+         reported in the format of UTC nor time zone offset to 
+         UTC.";    
+    }
+  }
+
+  grouping recurrence-UTC-with-date-times {
+    description
+      "This grouping defines an aggregate set of repeating 
+       occurrences with UTC time format. The recurrence instances 
+       are specified by the union of occurrences defined by both 
+       the recurrence rule and 'period-timeticks' list. Duplicate 
+       instances are ignored.";
+    uses recurrence-UTC;
+    list period-timeticks {
+      key "period-start";
+      description
+        "A list of period with timeticks formats.";      
+      leaf period-start {
+        type yang:timeticks;
+        must
+          "(not(derived-from(../../frequency,"
+         +"'schedule:secondly')) or (current() < 100)) and "
+         +"(not(derived-from(../../frequency,"
+         +"'schedule:minutely')) or (current() < 6000)) and "
+         +"(not(derived-from(../../frequency,'schedule:hourly'))"
+         +" or (current() < 360000)) and "
+         +"(not(derived-from(../../frequency,'schedule:daily'))"
+         +" or (current() < 8640000)) and "
+         +"(not(derived-from(../../frequency,'schedule:weekly'))"
+         +" or (current() < 60480000)) and "
+         +"(not(derived-from(../../frequency,"
+         +"'schedule:monthly')) or (current() < 267840000)) and "
+         +"(not(derived-from(../../frequency,'schedule:yearly'))"
+         +" or (current() < 3162240000))" {
+        error-message
+          "The period-start must not exceed the frequency 
+           interval.";
+        }        
         description
-          "Specify a list of occurrences with date-and-time
-           values.";
-          leaf-list date-times {
-            type yang:date-and-time;
-            description
-              "Specifies a set of date-and-time values of
-               occurrences.";
-          }
+          "Start time of the schedule within one recurrence.";
       }
-      case date {
+      leaf period-end {
+        type yang:timeticks;
         description
-          "Specifies a list of occurrences with date-no-zone
-           values.";
-          leaf-list dates {
-            type yang:date-no-zone;
-            description
-              "Specifies a set of date-no-zone values of
-               occurrences.";
-          }
-      }
-      case period-timeticks {
-        description
-          "Specifies a list of occurrences with period span of
-           timeticks format.";
-          list period-timeticks {
-            key "period-start";
-            description
-              "A list of period with timeticks formats.";
-            leaf period-start {
-              type yang:timeticks;
-              must
-              "(not(derived-from(../../frequency,"
-             +"'schedule:secondly')) or (current() < 100)) and "
-             +"(not(derived-from(../../frequency,"
-             +"'schedule:minutely')) or (current() < 6000)) and "
-             +"(not(derived-from(../../frequency,'schedule:hourly'))"
-             +" or (current() < 360000)) and "
-             +"(not(derived-from(../../frequency,'schedule:daily'))"
-             +" or (current() < 8640000)) and "
-             +"(not(derived-from(../../frequency,'schedule:weekly'))"
-             +" or (current() < 60480000)) and "
-             +"(not(derived-from(../../frequency,"
-             +"'schedule:monthly')) or (current() < 267840000)) and "
-             +"(not(derived-from(../../frequency,'schedule:yearly'))"
-             +" or (current() < 3162240000))" {
-                error-message
-                  "The period-start must not exceed the frequency
-                   interval.";
-              }
-              description
-                "Start time of the scheduled value within one
-                 recurrence.";
-            }
-            leaf period-end {
-              type yang:timeticks;
-              description
-                "End time of the scheduled value within one
-                 recurrence.";
-            }
-          }
-      }
-      case period {
-        description
-          "Specifies a list of occurrences with period span
-           of date-and -time format.";
-        list period {
-          key "period-start";
-          description
-            "A list of period with date-and-time formats.";
-          uses period-of-time;
-        }
-      }
+          "End time of the schedule within one recurrence.";
+      }      
+    }
+  }  
+  
+  grouping recurrence-TZ-with-date-times {
+    description
+      "This grouping defines an aggregate set of repeating 
+       occurrences with local time format and time zone specified. 
+       The recurrence instances are specified by the union of 
+       occurrences defined by both the recurrence rule and 'period' 
+       list. Duplicate instances are ignored.";  
+    uses recurrence-TZ;
+    list period {
+      key "period-start";
+      description
+        "A list of period with date-and-time formats.";
+      uses period-of-time;
     }
   }
 
   grouping icalendar-recurrence {
     description
-      "This grouping is defined to identify properties
-       that contain a recurrence rule.";
+      "This grouping is defined to identify properties that 
+       contain a recurrence rule.";
     reference
       "RFC 5545: Internet Calendaring and Scheduling
                  Core Object Specification (iCalendar),
                  Section 3.8.5";
-
-    uses recurrence-with-date-times;
+    uses recurrence-TZ-with-date-times;
     leaf-list bysecond {
       type uint32 {
         range "0..60";
@@ -573,10 +559,9 @@ module ietf-schedule {
         description
           "When specified, it indicates the nth occurrence of a
            specific day within the monthly or yearly recurrence
-           rule.
-           For example, within a monthly rule, +1 monday represents
-           the first monday within the month, whereas -1 monday
-           represents the last monday of the month.";
+           rule. For example, within a monthly rule, +1 monday 
+           represents the first monday within the month, whereas 
+           -1 monday represents the last monday of the month.";
       }
       leaf weekday {
         type schedule:weekday;
@@ -705,3 +690,4 @@ module ietf-schedule {
     }    
   }
 }
+

--- a/yang/ietf-schedule.yang
+++ b/yang/ietf-schedule.yang
@@ -408,7 +408,7 @@ module ietf-schedule {
     }
   }
   
-  grouping recurrence-UTC {
+  grouping recurrence-utc {
     description
       "A simple definition of recurrence with time specified in 
        UTC. This grouping is intended to be machine-friendly.";  
@@ -442,7 +442,7 @@ module ietf-schedule {
     }
   }
   
-  grouping recurrence-TZ {
+  grouping recurrence-with-time-zone {
     description
       "A simple definition of recurrence that allows the time to
        be specified with a local time and time zone. This grouping
@@ -464,7 +464,7 @@ module ietf-schedule {
           description
             "Indicates the identifier for the time zone in a time zone
              database. This parameter MUST be specified if 
-             'first-recur-date-time' and/or 'until' value is neither 
+             'date-time-start' and/or 'until' value is neither 
              reported in the format of UTC nor time zone offset to 
              UTC.";    
         }      
@@ -472,14 +472,14 @@ module ietf-schedule {
     }
   }
 
-  grouping recurrence-UTC-with-date-times {
+  grouping recurrence-utc-with-date-times {
     description
       "This grouping defines an aggregate set of repeating 
        occurrences with UTC time format. The recurrence instances 
        are specified by the union of occurrences defined by both 
        the recurrence rule and 'period-timeticks' list. Duplicate 
        instances are ignored.";
-    uses recurrence-UTC;
+    uses recurrence-utc;
     list period-timeticks {
       key "period-start";
       description
@@ -516,14 +516,14 @@ module ietf-schedule {
     }
   }  
   
-  grouping recurrence-TZ-with-date-times {
+  grouping recurrence-time-zone-with-date-times {
     description
       "This grouping defines an aggregate set of repeating 
        occurrences with local time format and time zone specified. 
        The recurrence instances are specified by the union of 
        occurrences defined by both the recurrence rule and 'period' 
        list. Duplicate instances are ignored.";  
-    uses recurrence-TZ;
+    uses recurrence-with-time-zone;
     list period {
       key "period-start";
       description
@@ -540,7 +540,7 @@ module ietf-schedule {
       "RFC 5545: Internet Calendaring and Scheduling
                  Core Object Specification (iCalendar),
                  Section 3.8.5";
-    uses recurrence-TZ-with-date-times;
+    uses recurrence-time-zone-with-date-times;
     leaf-list bysecond {
       type uint32 {
         range "0..60";


### PR DESCRIPTION
During the IETF 119 discussion with the authors of I-D. tvr-schedule-yang, they wish a machine-readable grouping without the time zone identifier parameter, and the duration value needs to be in units of seconds. This update is to incorporate the requirements and keep the definition modular at the same time.

Let me know if you have different thoughts on this.
